### PR TITLE
change the AVAudioSession Category before start, or it will fail

### DIFF
--- a/LFLiveKit/capture/LFAudioCapture.m
+++ b/LFLiveKit/capture/LFAudioCapture.m
@@ -124,6 +124,7 @@ NSString *const LFAudioComponentFailedToCreateNotification = @"LFAudioComponentF
         dispatch_async(self.taskQueue, ^{
             self.isRunning = YES;
             NSLog(@"MicrophoneSource: startRunning");
+            [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
             AudioOutputUnitStart(self.componetInstance);
         });
     } else {


### PR DESCRIPTION
把他集成进一个完整的项目时，如果在APP其他地方改变了AVAudioSession的Category, AudioUnitStat可能失败