### PR TITLE
Reset compression session when encoding error occurs

### DIFF
--- a/LFLiveKit/coder/LFHardwareVideoEncoder.m
+++ b/LFLiveKit/coder/LFHardwareVideoEncoder.m
@@ -107,7 +107,7 @@
     NSNumber *timeNumber = @(timeStamp);
 
     OSStatus status = VTCompressionSessionEncodeFrame(compressionSession, pixelBuffer, presentationTimeStamp, duration, (__bridge CFDictionaryRef)properties, (__bridge_retained void *)timeNumber, &flags);
-    if(status == noErr){
+    if(status != noErr){
         [self resetCompressionSession];
     }
 }


### PR DESCRIPTION
这个判断是否反了，status != 0时才resetCompressionSession