### PR TITLE
using NSMutableArray sortUsingFunction instead of NSArray sortedArray…

### DIFF
--- a/LFLiveKit/publish/LFStreamingBuffer.m
+++ b/LFLiveKit/publish/LFStreamingBuffer.m
@@ -62,9 +62,7 @@ static const NSUInteger defaultSendBufferMaxCount = 600;///< 最大缓冲区为6
     } else {
         ///< 排序
         [self.sortList addObject:frame];
-        NSArray *sortedSendQuery = [self.sortList sortedArrayUsingFunction:frameDataCompare context:NULL];
-        [self.sortList removeAllObjects];
-        [self.sortList addObjectsFromArray:sortedSendQuery];
+		[self.sortList sortUsingFunction:frameDataCompare context:nil];
         /// 丢帧
         [self removeExpireFrame];
         /// 添加至缓冲区


### PR DESCRIPTION
NSArray的排序方法是：sortedArrayUsingFunction
NSMutableArray的排序方法是：sortUsingFunction

self.sortList是一个NSMutableArray，直接使用NSMutableArray的排序方法sortUsingFunction不需要进行内存复制，可以提高性能；

另外在多线程中使用LFStreamSocket进行推流时（sample工程不是这么用的，没问题），不必要的内存复制会导致内存泄漏，出现的内存泄漏问题类似于：
http://stackoverflow.com/questions/5200857/memory-leaks-from-multidimensional-array-nsmutablearray-nsarray-addobject-and

