### PR TITLE
Prevent blocking UI while reconnecting.

### DIFF
--- a/LFLiveKit/publish/LFStreamRtmpSocket.m
+++ b/LFLiveKit/publish/LFStreamRtmpSocket.m
@@ -489,7 +489,7 @@ Failed:
             self.isConnecting = NO;
             self.isReconnecting = YES;
             dispatch_async(dispatch_get_main_queue(), ^{
-                 [self performSelector:@selector(_reconnect) withObject:nil afterDelay:self.reconnectInterval];
+                 [self performSelector:@selector(_delayedReconnect) withObject:nil afterDelay:self.reconnectInterval];
             });
            
         } else if (self.retryTimes4netWorkBreaken >= self.reconnectCount) {
@@ -503,9 +503,16 @@ Failed:
     });
 }
 
-- (void)_reconnect{
+- (void)_delayedReconnect {
     [NSObject cancelPreviousPerformRequestsWithTarget:self];
-    
+
+    dispatch_async(self.rtmpSendQueue, ^{
+	    [self _reconnect];
+    });
+}
+
+- (void)_reconnect {
+
     _isReconnecting = NO;
     if(_isConnected) return;
     


### PR DESCRIPTION
The _reconnect in LFStreamRtmpSocket method calls
-RTMP264_Connect:cStringUsingEncoding:, and it must be called in a
background thread, otherwise the UI is blocked.