### PR TITLE
fix/handling stop streaming

### DIFF
--- a/LFLiveKit/publish/LFStreamRtmpSocket.m
+++ b/LFLiveKit/publish/LFStreamRtmpSocket.m
@@ -291,6 +291,7 @@ SAVC(mp4a);
     _isConnecting = NO;
     _isReconnecting = NO;
     _isSending = NO;
+    _retryTimes4netWorkBreaken = 0;
     return 0;
 
 Failed:

--- a/LFLiveKit/publish/LFStreamRtmpSocket.m
+++ b/LFLiveKit/publish/LFStreamRtmpSocket.m
@@ -248,6 +248,9 @@ SAVC(mp4a);
 - (NSInteger)RTMP264_Connect:(char *)push_url {
     //由于摄像头的timestamp是一直在累加，需要每次得到相对时间戳
     //分配与初始化
+    char msg[100];
+    memset(msg, 0, 100);
+    PILI_RTMPError_Alloc(&_error, strlen(msg));
     _rtmp = PILI_RTMP_Alloc();
     PILI_RTMP_Init(_rtmp);
 

--- a/LFLiveKit/publish/LFStreamRtmpSocket.m
+++ b/LFLiveKit/publish/LFStreamRtmpSocket.m
@@ -113,6 +113,8 @@ SAVC(mp4a);
     if (_isConnecting) return;
     
     _isConnecting = YES;
+    _retryTimes4netWorkBreaken = 0;
+
     if (self.delegate && [self.delegate respondsToSelector:@selector(socketStatus:status:)]) {
         [self.delegate socketStatus:self status:LFLivePending];
     }


### PR DESCRIPTION
1. Set _retryTimes4netWorkBreaken = 0 to avoid when it doesn't stop successfully or not reset after reconnect successfully.
2. Set the error msg to empty to prevent it keeps the outdated error message after reconnect.